### PR TITLE
Enable automatic dark/light mode based on system preference

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -80,6 +80,13 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+
+      colorMode: {
+        defaultMode: 'system', // Use the system's default theme (dark/light)
+        respectPrefersColorScheme: true,
+        disableSwitch: false,
+      },
+
       // Replace with your project's social card
       // image: 'img/docusaurus-social-card.jpg',
       navbar: {


### PR DESCRIPTION
## Summary

This PR enables automatic dark/light theme detection based on the user's system preferences.

Docusaurus is now configured to use `defaultMode: 'system'`, so the site will automatically start in dark or light mode depending on the operating system settings.

## Changes

- Set `colorMode.defaultMode` to `system`
- Enabled `respectPrefersColorScheme`
- Kept the theme toggle switch available for manual override

## Behavior

- First-time visitors will see the theme matching their system setting
- Manual theme selection is still supported and stored in localStorage
- No visual or functional changes to the existing toggle button

## Motivation

This improves accessibility and user experience by respecting system-wide color preferences without requiring manual interaction.
