### PR TITLE
Update docs/installation.mdx

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -102,7 +102,7 @@ The Flatpak version may have its own limitations due to the "sandbox". [Read mor
 
 ## Download from GitHub Releases
 
-You can download releases above Floorp 10 from [GitHub Releases page](https://github.com/Floorp-Projects/Floorp/releases).
+You can download releases of Floorp 12 from [GitHub Releases page](https://github.com/Floorp-Projects/Floorp/releases).
 
 Please note that while it is possible to download and install older versions of Floorp from here, no support will be provided for them.
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -106,10 +106,4 @@ You can download releases above Floorp 10 from [GitHub Releases page](https://gi
 
 Please note that while it is possible to download and install older versions of Floorp from here, no support will be provided for them.
 
-## What is Floorp Daylight？
-
-Floorp Daylight is a beta version that gets updated more frequently. It may contain bugs due to features still under development.
-
-Additionally, some versions of Floorp Daylight might not be digitally signed due to the rapid release cycle.
-
 <Support />

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -106,4 +106,10 @@ You can download releases of Floorp 12 from [GitHub Releases page](https://githu
 
 Please note that while it is possible to download and install older versions of Floorp from here, no support will be provided for them.
 
+## What is Floorp Daylight?
+
+Currently, Floorp Daylight is the name of the debug build for developers. If you are interested in contributing to the development of the Floorp Browser, please refer to [`CONTRIBUTING.md`](https://github.com/Floorp-Projects/Floorp/blob/main/.github/CONTRIBUTING.md) in the official repository.
+
+Previously, Floorp Daylight was the name of the public beta build. We have now introduced a progressive rollout system for experimental features in the stable version of Floorp ([Floorp Flasco](https://docs.floorp.app/docs/features/glossary/#floorp-flasco)). This allows you to try out new features without needing to install a separate browser.
+
 <Support />


### PR DESCRIPTION
2 commits to remove and update outdated information from docs/installation.mdx. 

1. A version number is updated from 10 to 12 to reflct the contents of the releases page.
2. A section related to the no longer downloadable Floorp Daylight is removed.